### PR TITLE
updated for godot 4.1 added a C# version of the GDScripts

### DIFF
--- a/Better Drag and Drop.csproj
+++ b/Better Drag and Drop.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Godot.NET.Sdk/4.1.0">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <RootNamespace>BetterDragandDrop</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/Better Drag and Drop.sln
+++ b/Better Drag and Drop.sln
@@ -1,0 +1,19 @@
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Better Drag and Drop", "Better Drag and Drop.csproj", "{FD28006D-3AF0-4DDE-8CEF-863B41285BBB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+	Debug|Any CPU = Debug|Any CPU
+	ExportDebug|Any CPU = ExportDebug|Any CPU
+	ExportRelease|Any CPU = ExportRelease|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FD28006D-3AF0-4DDE-8CEF-863B41285BBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD28006D-3AF0-4DDE-8CEF-863B41285BBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD28006D-3AF0-4DDE-8CEF-863B41285BBB}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
+		{FD28006D-3AF0-4DDE-8CEF-863B41285BBB}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
+		{FD28006D-3AF0-4DDE-8CEF-863B41285BBB}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
+		{FD28006D-3AF0-4DDE-8CEF-863B41285BBB}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/CSharp/DraggableSprite.cs
+++ b/CSharp/DraggableSprite.cs
@@ -1,0 +1,54 @@
+using Godot;
+
+public partial class DraggableSprite : Sprite2D
+{
+	public bool mouseIn;
+	public bool dragging = false;
+	public bool mouseToCenterSet = false;
+	public Vector2 mouseToCenter;
+	public Vector2 spritePos;
+	public Vector2 mousePos;
+
+	public override void _UnhandledInput(InputEvent @event)
+	{
+		if (!Input.IsActionJustPressed("left_click") || !mouseIn) // When clicking
+			return;
+
+		// First we set mouseToCenter as a static vector
+		// for preventing the sprite to move its center to the mouse position
+		mousePos = GetViewport().GetMousePosition();
+		mouseToCenter = RestaVectores(Position, mousePos);
+	}
+	
+	public override void _Process(double _delta)
+	{
+		if (!dragging)
+			return;
+
+		mousePos = GetViewport().GetMousePosition();
+		//Set the position of the sprite to mouse position + static mouseToCenter vector
+		Position = SumaVectores(mousePos, mouseToCenter);
+	}
+	
+	public void _OnArea2DMouseEntered()
+	{
+		mouseIn = true;
+		(GetParent() as DraggableSpriteManager)?._AddSprite(this) ;//Add the sprite to the sprite list
+	}
+	
+	public void _OnArea2DMouseExited()
+	{
+		mouseIn = false;
+		(GetParent() as DraggableSpriteManager)?._RemoveSprite(this)  ;//Remove the sprite from the sprite list
+	}
+	
+	public Vector2 RestaVectores(Vector2 v1, Vector2 v2)
+	{
+		return new Vector2(v1.X - v2.X, v1.Y - v2.Y);  //vector substraction
+	}
+	
+	public Vector2 SumaVectores(Vector2 v1, Vector2 v2)
+	{   
+		return new Vector2(v1.X + v2.X, v1.Y + v2.Y);  //vector sum
+	}
+}

--- a/CSharp/DraggableSprite.tscn
+++ b/CSharp/DraggableSprite.tscn
@@ -1,14 +1,14 @@
-[gd_scene load_steps=4 format=3 uid="uid://3u0w6c1y4cml"]
+[gd_scene load_steps=4 format=3 uid="uid://3o5yosnedjeg"]
 
 [ext_resource type="Texture2D" uid="uid://us48jqh702tx" path="res://icon.png" id="1"]
-[ext_resource type="Script" path="res://Sprite.gd" id="2"]
+[ext_resource type="Script" path="res://CSharp/DraggableSprite.cs" id="2_5cd0x"]
 
 [sub_resource type="RectangleShape2D" id="1"]
 size = Vector2(60, 60)
 
 [node name="Sprite2D" type="Sprite2D"]
 texture = ExtResource("1")
-script = ExtResource("2")
+script = ExtResource("2_5cd0x")
 
 [node name="Area2D" type="Area2D" parent="."]
 
@@ -16,5 +16,5 @@ script = ExtResource("2")
 position = Vector2(-4.76837e-07, -9.53674e-07)
 shape = SubResource("1")
 
-[connection signal="mouse_entered" from="Area2D" to="." method="_on_Area2D_mouse_entered"]
-[connection signal="mouse_exited" from="Area2D" to="." method="_on_Area2D_mouse_exited"]
+[connection signal="mouse_entered" from="Area2D" to="." method="_OnArea2DMouseEntered"]
+[connection signal="mouse_exited" from="Area2D" to="." method="_OnArea2DMouseExited"]

--- a/CSharp/DraggableSpriteManager.cs
+++ b/CSharp/DraggableSpriteManager.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Godot;
+
+public partial class DraggableSpriteManager : Node
+{
+	// Made with love by JuanCarlos "Juanky" Aguilera
+	// Github Repo: https://github.com/JCAguilera/godot3-drag-and-drop
+
+	private List<DraggableSprite> sprites = new();
+	private DraggableSprite topSprite;
+
+	private RichTextLabel status;
+	private RichTextLabel spriteList;
+	
+	public override void _Ready()
+	{
+		status = GetNode<RichTextLabel>("Status");
+		spriteList = GetNode<RichTextLabel>("SpriteList");
+	}
+
+	public override void _UnhandledInput(InputEvent @event)
+	{
+		if (Input.IsActionJustPressed("left_click")) //When we click
+		{
+			topSprite = _TopSprite(); // Get the sprite on Top (largest zIndex)
+			if (topSprite != null) // If there's a sprite
+				topSprite.dragging = true; // We set dragging to true
+		}
+
+		if (Input.IsActionJustReleased("left_click")) //When we release
+		{
+			if (topSprite != null)
+			{
+				topSprite.dragging = false; //Set dragging to false
+				topSprite = null; // Top sprite to null
+			}
+		}
+		_PrintStatus();
+	}
+	
+	// Add sprite to list
+	public void _AddSprite(DraggableSprite sprite)
+	{   
+		if (sprites.Contains(sprite))  // If sprite exists
+			return;  // Do nothing
+		
+		sprites.Add(sprite);  // Add sprite to list
+	}
+	
+	// Remove sprite from the list
+	public void _RemoveSprite(DraggableSprite sprite)
+	{
+		sprites.Remove(sprite);
+	}
+	
+	// Get the top sprite
+	public DraggableSprite _TopSprite()
+	{
+		if (!sprites.Any())  // If the list is empty
+			return null;
+
+		return sprites.OrderByDescending(sprite => sprite.ZIndex).First(); // Return top sprite, sorted by ZIndex
+	}
+	
+	public void _PrintStatus()
+	{  
+		List<int> auxSprt = new List<int>();
+		List<bool> auxSprtCanDrag = new List<bool>();
+		
+		foreach(var i in sprites)
+			auxSprt.Add(i.ZIndex);
+		
+		foreach(var i in sprites)
+			auxSprtCanDrag.Add(i.dragging);
+		
+		if (topSprite != null)
+			status.Text = "Top: " + topSprite.ZIndex + " - Dragging: " + topSprite.dragging;
+		else
+			status.Text = "Top: null - Dragging: False";
+			
+		spriteList.Text = "Sprites: " + string.Join(',', auxSprt) + " - Can drag: " + string.Join(',', auxSprtCanDrag);
+	}
+}

--- a/CSharp/World_CSharp.tscn
+++ b/CSharp/World_CSharp.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=3 format=3 uid="uid://b5wtf4hkumir7"]
+
+[ext_resource type="Script" path="res://CSharp/DraggableSpriteManager.cs" id="1_pgajw"]
+[ext_resource type="PackedScene" uid="uid://3o5yosnedjeg" path="res://CSharp/DraggableSprite.tscn" id="2_2y2sm"]
+
+[node name="Node" type="Node"]
+script = ExtResource("1_pgajw")
+
+[node name="Sprite1" parent="." instance=ExtResource("2_2y2sm")]
+position = Vector2(434, 233)
+
+[node name="Sprite2" parent="." instance=ExtResource("2_2y2sm")]
+z_index = 1
+position = Vector2(203, 143)
+
+[node name="Sprite3" parent="." instance=ExtResource("2_2y2sm")]
+z_index = 2
+position = Vector2(611, 103)
+
+[node name="Status" type="RichTextLabel" parent="."]
+offset_left = 13.0
+offset_top = 531.0
+offset_right = 737.0
+offset_bottom = 547.0
+text = "dummy"
+
+[node name="SpriteList" type="RichTextLabel" parent="."]
+offset_left = 13.0
+offset_top = 555.0
+offset_right = 737.0
+offset_bottom = 575.0
+text = "dummy"

--- a/Main.gd
+++ b/Main.gd
@@ -6,8 +6,8 @@ extends Node
 var sprites = []
 var top_sprite = null
 
-onready var status = $Status
-onready var spriteList = $SpriteList
+@onready var status = $Status
+@onready var spriteList = $SpriteList
 
 func _input(_event):
 	if Input.is_action_just_pressed("left_click"): #When we click
@@ -33,12 +33,12 @@ func _add_sprite(sprt): #Add sprite to list
 
 func _remove_sprite(sprt): #Remove sprite from list
 	var idx = sprites.find(sprt) #find the index
-	sprites.remove(idx) #remove
+	sprites.remove_at(idx) #remove
 
 func _top_sprite(): #Get the top sprite
 	if len(sprites) == 0: #If the list is empty
 		return null
-	sprites.sort_custom(SpritesSorter, "z_index") #Sort by z_index
+	sprites.sort_custom(Callable(SpritesSorter, "z_index")) #Sort by z_index
 	return sprites[0] #Return top sprite
 
 #Print status

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Now, that method requires the use of Collision Shapes and Area2D nodes, and I di
 My brain was not working at a 100% when I made this example, so I think a lot of code can be improved. Please feel free to help me improve this example, so we can help more people.  
 Thanks [cezuriku](https://github.com/cezuriku) for simplyfing the code and updating it to Godot 3.2!
 
+## Godot 4 and C#
+
+This version is now working with Godot 4.1 and there are also a C# versions of the GDScripts in the folder "CSharp". To use this version in the example project, you need to set the Main Scene to `res://CSharp/World_CSharp.tscn` in Project Settings > General > Application > Run.
+
 ## License
 
 MIT License - see [LICENSE](LICENSE) for more details.

--- a/Sprite.gd
+++ b/Sprite.gd
@@ -1,4 +1,4 @@
-extends Sprite
+extends Sprite2D
 
 var mouse_in = false
 var dragging = false

--- a/World.tscn
+++ b/World.tscn
@@ -1,35 +1,32 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=3 format=3 uid="uid://cxgpqyo7kcoce"]
 
-[ext_resource path="res://Main.gd" type="Script" id=1]
-[ext_resource path="res://Drag_and_Drop_Sprite.tscn" type="PackedScene" id=2]
+[ext_resource type="Script" path="res://Main.gd" id="1"]
+[ext_resource type="PackedScene" uid="uid://3u0w6c1y4cml" path="res://Drag_and_Drop_Sprite.tscn" id="2"]
 
 [node name="Node" type="Node"]
-script = ExtResource( 1 )
+script = ExtResource("1")
 
-[node name="Sprite1" parent="." instance=ExtResource( 2 )]
-position = Vector2( 434, 233 )
+[node name="Sprite1" parent="." instance=ExtResource("2")]
+position = Vector2(434, 233)
 
-[node name="Sprite2" parent="." instance=ExtResource( 2 )]
-position = Vector2( 203, 143 )
+[node name="Sprite2" parent="." instance=ExtResource("2")]
 z_index = 1
+position = Vector2(203, 143)
 
-[node name="Sprite3" parent="." instance=ExtResource( 2 )]
-position = Vector2( 611, 103 )
+[node name="Sprite3" parent="." instance=ExtResource("2")]
 z_index = 2
+position = Vector2(611, 103)
 
 [node name="Status" type="RichTextLabel" parent="."]
-margin_left = 13.0
-margin_top = 531.0
-margin_right = 737.0
-margin_bottom = 547.0
+offset_left = 13.0
+offset_top = 531.0
+offset_right = 737.0
+offset_bottom = 547.0
 text = "dummy"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="SpriteList" type="RichTextLabel" parent="."]
-margin_left = 13.0
-margin_top = 555.0
-margin_right = 737.0
-margin_bottom = 575.0
+offset_left = 13.0
+offset_top = 555.0
+offset_right = 737.0
+offset_bottom = 575.0
 text = "dummy"

--- a/default_env.tres
+++ b/default_env.tres
@@ -1,18 +1,8 @@
-[gd_resource type="Environment" load_steps=2 format=2]
+[gd_resource type="Environment" load_steps=2 format=3 uid="uid://cjy57lbtbdrw0"]
 
-[sub_resource type="ProceduralSky" id=1]
+[sub_resource type="Sky" id="1"]
 radiance_size = 4
-sky_top_color = Color( 0.0470588, 0.454902, 0.976471, 1 )
-sky_horizon_color = Color( 0.556863, 0.823529, 0.909804, 1 )
-sky_curve = 0.25
-ground_bottom_color = Color( 0.101961, 0.145098, 0.188235, 1 )
-ground_horizon_color = Color( 0.482353, 0.788235, 0.952941, 1 )
-ground_curve = 0.01
-sun_energy = 16.0
 
 [resource]
 background_mode = 2
-background_sky = SubResource( 1 )
-fog_height_min = 0.0
-fog_height_max = 100.0
-ssao_quality = 0
+sky = SubResource("1")

--- a/icon.png.import
+++ b/icon.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
+type="CompressedTexture2D"
+uid="uid://us48jqh702tx"
+path="res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://icon.png"
-dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_files=["res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/project.godot
+++ b/project.godot
@@ -6,27 +6,32 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=4
-
-_global_script_classes=[  ]
-_global_script_class_icons={
-
-}
+config_version=5
 
 [application]
 
 config/name="Better Drag and Drop"
 run/main_scene="res://World.tscn"
+config/features=PackedStringArray("4.1", "C#")
 config/icon="res://icon.png"
+
+[dotnet]
+
+project/assembly_name="Better Drag and Drop"
+
 
 [input]
 
 left_click={
 "deadzone": 0.5,
-"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":1,"pressed":false,"doubleclick":false,"script":null)
- ]
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
 }
+
+[mono]
+
+project/assembly_name="Better Drag and Drop"
 
 [rendering]
 
-environment/default_environment="res://default_env.tres"
+environment/defaults/default_environment="res://default_env.tres"


### PR DESCRIPTION
* updated for godot v4.1
* added a CSharp version of the GDScripts
* added paragraph for using the C# version in README

For using the C# version in the example project, you need to set the Main Scene to `res://CSharp/World_CSharp.tscn`
![grafik](https://github.com/JCAguilera/better-drag-and-drop-sprite/assets/26973123/12fd0678-476d-46f4-bca0-618a15d734a9)
